### PR TITLE
Reformat codebase using Square's Android code style

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,15 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'com.novoda:bintray-release:0.3.4'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:1.3.0'
+    classpath 'com.novoda:bintray-release:0.3.4'
+  }
 }
 
 allprojects {
-    repositories {
-        jcenter()
-    }
+  repositories {
+    jcenter()
+  }
 }

--- a/cafejava/build.gradle
+++ b/cafejava/build.gradle
@@ -2,49 +2,49 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 publish {
-    userOrg = 'milbuild'
-    groupId = 'com.ibm.mil'
-    artifactId = 'cafejava'
-    publishVersion = '2.0.0'
-    desc = 'RxJava extensions for the MobileFirst Platform (MFP) Android API'
-    website = 'https://github.com/IBM-MIL/CafeJava'
+  userOrg = 'milbuild'
+  groupId = 'com.ibm.mil'
+  artifactId = 'cafejava'
+  publishVersion = '2.0.0'
+  desc = 'RxJava extensions for the MobileFirst Platform (MFP) Android API'
+  website = 'https://github.com/IBM-MIL/CafeJava'
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
-    useLibrary 'org.apache.http.legacy'
+  compileSdkVersion 23
+  buildToolsVersion '23.0.1'
+  useLibrary 'org.apache.http.legacy'
 
-    defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 23
-        versionCode 1
-        versionName '1.0'
+  defaultConfig {
+    minSdkVersion 9
+    targetSdkVersion 23
+    versionCode 1
+    versionName '1.0'
+  }
+  lintOptions {
+    abortOnError false
+  }
+  testOptions {
+    unitTests.returnDefaultValues = true
+  }
+  buildTypes {
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
-    lintOptions {
-        abortOnError false
-    }
-    testOptions {
-        unitTests.returnDefaultValues = true
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-    packagingOptions {
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/ASL2.0'
-    }
+  }
+  packagingOptions {
+    exclude 'META-INF/NOTICE'
+    exclude 'META-INF/LICENSE'
+    exclude 'META-INF/ASL2.0'
+  }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.ibm.mobile.foundation:ibmmobilefirstplatformfoundation:7.1.0.0'
-    compile 'com.android.support:support-annotations:23.1.1'
-    compile 'io.reactivex:rxjava:1.1.0'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+  compile fileTree(dir: 'libs', include: ['*.jar'])
+  compile 'com.ibm.mobile.foundation:ibmmobilefirstplatformfoundation:7.1.0.0'
+  compile 'com.android.support:support-annotations:23.1.1'
+  compile 'io.reactivex:rxjava:1.1.0'
+  testCompile 'junit:junit:4.12'
+  testCompile 'org.mockito:mockito-core:1.9.5'
 }

--- a/cafejava/src/main/java/com/ibm/mil/cafejava/CafeJava.java
+++ b/cafejava/src/main/java/com/ibm/mil/cafejava/CafeJava.java
@@ -7,12 +7,10 @@ package com.ibm.mil.cafejava;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-
 import com.worklight.wlclient.api.WLClient;
 import com.worklight.wlclient.api.WLFailResponse;
 import com.worklight.wlclient.api.WLResponse;
 import com.worklight.wlclient.api.WLResponseListener;
-
 import rx.Observable;
 import rx.Subscriber;
 
@@ -27,70 +25,66 @@ import rx.Subscriber;
  */
 public final class CafeJava {
 
-    private CafeJava() {
-        throw new AssertionError(CafeJava.class.getName() + " is non-instantiable");
+  private CafeJava() {
+    throw new AssertionError(CafeJava.class.getName() + " is non-instantiable");
+  }
+
+  /**
+   * Creates an {@code Observable} that emits a {@code WLResponse} after attempting connection
+   * to the MFP server instance defined in the {@code wlclient.properties} file. This
+   * connection is only performed when there is a new {@code Subscriber} to the {@code
+   * Observable}. The {@code Observable} will automatically perform its work on a dedicated
+   * background thread, so there is usually no need to use the {@code subscribeOn} method of
+   * RxJava.
+   *
+   * @return {@code Observable} that emits a {@code WLResponse} for an MFP connection.
+   */
+  @NonNull public static Observable<WLResponse> connect(@NonNull final Context context) {
+    return Observable.create(new Observable.OnSubscribe<WLResponse>() {
+      @Override public void call(Subscriber<? super WLResponse> subscriber) {
+        WLClient client = WLClient.createInstance(context);
+        client.connect(new RxResponseListener(subscriber));
+      }
+    });
+  }
+
+  /**
+   * Creates an {@code Observable} that emits a {@code WLResponse} after attempting to invoke
+   * the {@code ProcedureInvoker} parameter that is passed in. This invocation is only
+   * performed when there is a new {@code Subscriber} to the {@code Observable}. The {@code
+   * Observable} will automatically perform its work on a dedicated background thread, so there
+   * is usually no need to use the {@code subscribeOn} method of RxJava.
+   *
+   * @param invoker Implementation for a procedure invocation, most commonly
+   * {@link JavaProcedureInvoker} or {@link JSProcedureInvoker}.
+   * @return {@code Observable} that emits a {@code WLResponse} for an MFP procedure invocation.
+   */
+  @NonNull public static Observable<WLResponse> invokeProcedure(
+      @NonNull final ProcedureInvoker invoker) {
+    return Observable.create(new Observable.OnSubscribe<WLResponse>() {
+      @Override public void call(Subscriber<? super WLResponse> subscriber) {
+        invoker.invoke(new RxResponseListener(subscriber));
+      }
+    });
+  }
+
+  private static class RxResponseListener implements WLResponseListener {
+    private final Subscriber<? super WLResponse> subscriber;
+
+    RxResponseListener(Subscriber<? super WLResponse> subscriber) {
+      this.subscriber = subscriber;
     }
 
-    /**
-     * Creates an {@code Observable} that emits a {@code WLResponse} after attempting connection
-     * to the MFP server instance defined in the {@code wlclient.properties} file. This
-     * connection is only performed when there is a new {@code Subscriber} to the {@code
-     * Observable}. The {@code Observable} will automatically perform its work on a dedicated
-     * background thread, so there is usually no need to use the {@code subscribeOn} method of
-     * RxJava.
-     *
-     * @param context
-     * @return {@code Observable} that emits a {@code WLResponse} for an MFP connection.
-     */
-    @NonNull
-    public static Observable<WLResponse> connect(@NonNull final Context context) {
-        return Observable.create(new Observable.OnSubscribe<WLResponse>() {
-            @Override
-            public void call(Subscriber<? super WLResponse> subscriber) {
-                WLClient client = WLClient.createInstance(context);
-                client.connect(new RxResponseListener(subscriber));
-            }
-        });
+    @Override public void onSuccess(WLResponse wlResponse) {
+      subscriber.onNext(wlResponse);
+      subscriber.onCompleted();
     }
 
-    /**
-     * Creates an {@code Observable} that emits a {@code WLResponse} after attempting to invoke
-     * the {@code ProcedureInvoker} parameter that is passed in. This invocation is only
-     * performed when there is a new {@code Subscriber} to the {@code Observable}. The {@code
-     * Observable} will automatically perform its work on a dedicated background thread, so there
-     * is usually no need to use the {@code subscribeOn} method of RxJava.
-     *
-     * @param invoker Implementation for a procedure invocation, most commonly
-     *                {@link JavaProcedureInvoker} or {@link JSProcedureInvoker}.
-     * @return {@code Observable} that emits a {@code WLResponse} for an MFP procedure invocation.
-     */
-    @NonNull
-    public static Observable<WLResponse> invokeProcedure(@NonNull final ProcedureInvoker invoker) {
-        return Observable.create(new Observable.OnSubscribe<WLResponse>() {
-            @Override public void call(Subscriber<? super WLResponse> subscriber) {
-                invoker.invoke(new RxResponseListener(subscriber));
-            }
-        });
+    @Override public void onFailure(WLFailResponse wlFailResponse) {
+      String failureMessage =
+          String.format("Error Code: %s\nError Message: %s", wlFailResponse.getErrorCode(),
+              wlFailResponse.getErrorMsg());
+      subscriber.onError(new Throwable(failureMessage));
     }
-
-    private static class RxResponseListener implements WLResponseListener {
-        private final Subscriber<? super WLResponse> subscriber;
-
-        RxResponseListener(Subscriber<? super WLResponse> subscriber) {
-            this.subscriber = subscriber;
-        }
-
-        @Override
-        public void onSuccess(WLResponse wlResponse) {
-            subscriber.onNext(wlResponse);
-            subscriber.onCompleted();
-        }
-
-        @Override
-        public void onFailure(WLFailResponse wlFailResponse) {
-            String failureMessage = String.format("Error Code: %s\nError Message: %s",
-                    wlFailResponse.getErrorCode(), wlFailResponse.getErrorMsg());
-            subscriber.onError(new Throwable(failureMessage));
-        }
-    }
+  }
 }

--- a/cafejava/src/main/java/com/ibm/mil/cafejava/JSProcedureInvoker.java
+++ b/cafejava/src/main/java/com/ibm/mil/cafejava/JSProcedureInvoker.java
@@ -6,13 +6,10 @@
 package com.ibm.mil.cafejava;
 
 import android.support.annotation.Nullable;
-
 import com.worklight.wlclient.api.WLResourceRequest;
 import com.worklight.wlclient.api.WLResponseListener;
-
-import org.codehaus.jackson.map.ObjectMapper;
-
 import java.net.URI;
+import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Implementation for invoking a procedure from a JavaScript based adapter.
@@ -23,27 +20,24 @@ import java.net.URI;
  * @author Tanner Preiss (github @t-preiss)
  */
 public final class JSProcedureInvoker implements ProcedureInvoker {
-    private final String adapterName;
-    private final String procedureName;
-    private final Object[] params;
+  private final String adapterName;
+  private final String procedureName;
+  private final Object[] params;
 
-    public JSProcedureInvoker(String adapterName, String procedureName,
-                              @Nullable Object... params) {
-        this.adapterName = adapterName;
-        this.procedureName = procedureName;
-        this.params = params;
+  public JSProcedureInvoker(String adapterName, String procedureName, @Nullable Object... params) {
+    this.adapterName = adapterName;
+    this.procedureName = procedureName;
+    this.params = params;
+  }
+
+  @Override public void invoke(WLResponseListener wlResponseListener) {
+    try {
+      URI path = new URI("/adapters/" + adapterName + "/" + procedureName);
+      WLResourceRequest request = new WLResourceRequest(path, WLResourceRequest.GET);
+      request.setQueryParameter("params", new ObjectMapper().writeValueAsString(params));
+      request.send(wlResponseListener);
+    } catch (Exception e) {
+      e.printStackTrace();
     }
-
-    @Override
-    public void invoke(WLResponseListener wlResponseListener) {
-        try {
-            URI path = new URI("/adapters/" + adapterName + "/" + procedureName);
-            WLResourceRequest request = new WLResourceRequest(path, WLResourceRequest.GET);
-            request.setQueryParameter("params", new ObjectMapper().writeValueAsString(params));
-            request.send(wlResponseListener);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
+  }
 }

--- a/cafejava/src/main/java/com/ibm/mil/cafejava/JavaProcedureInvoker.java
+++ b/cafejava/src/main/java/com/ibm/mil/cafejava/JavaProcedureInvoker.java
@@ -7,10 +7,8 @@ package com.ibm.mil.cafejava;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.StringDef;
-
 import com.worklight.wlclient.api.WLResourceRequest;
 import com.worklight.wlclient.api.WLResponseListener;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URI;
@@ -27,108 +25,102 @@ import java.util.Map;
  * @author Tanner Preiss (github @t-preiss)
  */
 public final class JavaProcedureInvoker implements ProcedureInvoker {
-    /** StringDef for basic HTTP method types: {@code GET, POST, PUT, DELETE}. */
-    @Retention(RetentionPolicy.SOURCE)
-    @StringDef({
-            GET,
-            POST,
-            PUT,
-            DELETE
-    })
-    public @interface HttpMethod {}
-    /** Annotated with the {@code HttpMethod} StringDef */
-    public static final String GET = WLResourceRequest.GET;
-    /** Annotated with the {@code HttpMethod} StringDef */
-    public static final String POST = WLResourceRequest.POST;
-    /** Annotated with the {@code HttpMethod} StringDef */
-    public static final String PUT = WLResourceRequest.PUT;
-    /** Annotated with the {@code HttpMethod} StringDef */
-    public static final String DELETE = WLResourceRequest.DELETE;
+  /** StringDef for basic HTTP method types: {@code GET, POST, PUT, DELETE}. */
+  @Retention(RetentionPolicy.SOURCE)
+  @StringDef({ GET, POST, PUT, DELETE })
+  public @interface HttpMethod {}
 
+  /** Annotated with the {@code HttpMethod} StringDef */
+  public static final String GET = WLResourceRequest.GET;
+  /** Annotated with the {@code HttpMethod} StringDef */
+  public static final String POST = WLResourceRequest.POST;
+  /** Annotated with the {@code HttpMethod} StringDef */
+  public static final String PUT = WLResourceRequest.PUT;
+  /** Annotated with the {@code HttpMethod} StringDef */
+  public static final String DELETE = WLResourceRequest.DELETE;
+
+  private final String adapterName;
+  private final String path;
+  private HashMap<String, String> pathParams;
+  private HashMap<String, String> queryParams;
+  private @HttpMethod String httpMethod;
+
+  private JavaProcedureInvoker(String adapterName, String path) {
+    this.adapterName = adapterName;
+    this.path = path;
+  }
+
+  @Override public void invoke(WLResponseListener wlResponseListener) {
+    try {
+      URI uri = new URI("adapters/" + adapterName + buildPath(path, pathParams));
+      WLResourceRequest request = new WLResourceRequest(uri, httpMethod);
+      request.setQueryParameters(queryParams);
+      request.send(pathParams, wlResponseListener);
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static String buildPath(String path, Map<String, String> params) {
+    // insert initial forward slash if missing
+    if (!path.startsWith("/")) {
+      path = "/" + path;
+    }
+
+    // inject each path param into path
+    for (Map.Entry<String, String> param : params.entrySet()) {
+      // replace param name delimited by curly braces with param value
+      path = path.replace("{" + param.getKey() + "}", param.getValue());
+    }
+
+    return path;
+  }
+
+  /** Configures and instantiates a {@code JavaProcedureInvoker}. */
+  public static class Builder {
     private final String adapterName;
     private final String path;
-    private HashMap<String, String> pathParams;
-    private HashMap<String, String> queryParams;
-    private @HttpMethod String httpMethod;
+    private final HashMap<String, String> pathParams = new HashMap<>();
+    private final HashMap<String, String> queryParams = new HashMap<>();
+    private @HttpMethod String httpMethod = GET;
 
-    private JavaProcedureInvoker(String adapterName, String path) {
-        this.adapterName = adapterName;
-        this.path = path;
+    public Builder(String adapterName, String path) {
+      this.adapterName = adapterName;
+      this.path = path;
     }
 
-    @Override
-    public void invoke(WLResponseListener wlResponseListener) {
-        try {
-            URI uri = new URI("adapters/" + adapterName + buildPath(path, pathParams));
-            WLResourceRequest request = new WLResourceRequest(uri, httpMethod);
-            request.setQueryParameters(queryParams);
-            request.send(pathParams, wlResponseListener);
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
+    public Builder pathParam(@NonNull String name, @NonNull String value) {
+      pathParams.put(name, value);
+      return this;
     }
 
-    private static String buildPath(String path, Map<String, String> params) {
-        // insert initial forward slash if missing
-        if (!path.startsWith("/")) {
-            path = "/" + path;
-        }
-
-        // inject each path param into path
-        for (Map.Entry<String, String> param : params.entrySet()) {
-            // replace param name delimited by curly braces with param value
-            path = path.replace("{" + param.getKey() + "}", param.getValue());
-        }
-
-        return path;
+    public Builder pathParams(@NonNull Map<String, String> params) {
+      pathParams.putAll(params);
+      return this;
     }
 
-    /** Configures and instantiates a {@code JavaProcedureInvoker}. */
-    public static class Builder {
-        private final String adapterName;
-        private final String path;
-        private final HashMap<String, String> pathParams = new HashMap<>();
-        private final HashMap<String, String> queryParams = new HashMap<>();
-        private @HttpMethod String httpMethod = GET;
-
-        public Builder(String adapterName, String path) {
-            this.adapterName = adapterName;
-            this.path = path;
-        }
-
-        public Builder pathParam(@NonNull String name, @NonNull String value) {
-            pathParams.put(name, value);
-            return this;
-        }
-
-        public Builder pathParams(@NonNull Map<String, String> params) {
-            pathParams.putAll(params);
-            return this;
-        }
-
-        public Builder queryParam(@NonNull String name, @NonNull String value) {
-            queryParams.put(name, value);
-            return this;
-        }
-
-        public Builder queryParams(@NonNull Map<String, String> params) {
-            queryParams.putAll(params);
-            return this;
-        }
-
-        /** Expects an {@code HttpMethod} StringDef constant value. Default is {@code GET}. */
-        public Builder httpMethod(@NonNull @HttpMethod String httpMethod) {
-            this.httpMethod = httpMethod;
-            return this;
-        }
-
-        public JavaProcedureInvoker build() {
-            JavaProcedureInvoker invoker = new JavaProcedureInvoker(adapterName, path);
-            invoker.pathParams = pathParams;
-            invoker.queryParams = queryParams;
-            invoker.httpMethod = httpMethod;
-            return invoker;
-        }
+    public Builder queryParam(@NonNull String name, @NonNull String value) {
+      queryParams.put(name, value);
+      return this;
     }
 
+    public Builder queryParams(@NonNull Map<String, String> params) {
+      queryParams.putAll(params);
+      return this;
+    }
+
+    /** Expects an {@code HttpMethod} StringDef constant value. Default is {@code GET}. */
+    public Builder httpMethod(@NonNull @HttpMethod String httpMethod) {
+      this.httpMethod = httpMethod;
+      return this;
+    }
+
+    public JavaProcedureInvoker build() {
+      JavaProcedureInvoker invoker = new JavaProcedureInvoker(adapterName, path);
+      invoker.pathParams = pathParams;
+      invoker.queryParams = queryParams;
+      invoker.httpMethod = httpMethod;
+      return invoker;
+    }
+  }
 }

--- a/cafejava/src/main/java/com/ibm/mil/cafejava/JsonConverter.java
+++ b/cafejava/src/main/java/com/ibm/mil/cafejava/JsonConverter.java
@@ -2,14 +2,10 @@ package com.ibm.mil.cafejava;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import com.worklight.wlclient.api.WLResponse;
-
+import java.io.IOException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
-
-import java.io.IOException;
-
 import rx.Observable;
 import rx.Subscriber;
 
@@ -27,70 +23,70 @@ import rx.Subscriber;
  * @author Tanner Preiss (github @t-preiss)
  */
 public class JsonConverter<T> implements Observable.Operator<T, WLResponse> {
-    private Class<T> clazz;
-    private TypeReference<T> reference;
+  private Class<T> clazz;
+  private TypeReference<T> reference;
 
-    /**
-     * Allows for conversion from JSON objects.
-     *
-     * @param clazz The targeted class for conversion
-     */
-    public JsonConverter(@NonNull Class<T> clazz) {
-        this.clazz = clazz;
-    }
+  /**
+   * Allows for conversion from JSON objects.
+   *
+   * @param clazz The targeted class for conversion
+   */
+  public JsonConverter(@NonNull Class<T> clazz) {
+    this.clazz = clazz;
+  }
 
-    /**
-     * Allows for conversion from JSON arrays. {@code TypeReference<T>} must be used for converting
-     * to a type of {@code List<T>}. To do this, you would call:
-     * {@code new TypeReference<List<T>>() {}}.
-     *
-     * @param reference The targeted {@code List<T>} for conversion
-     */
-    public JsonConverter(@NonNull TypeReference<T> reference) {
-        this.reference = reference;
-    }
+  /**
+   * Allows for conversion from JSON arrays. {@code TypeReference<T>} must be used for converting
+   * to a type of {@code List<T>}. To do this, you would call:
+   * {@code new TypeReference<List<T>>() {}}.
+   *
+   * @param reference The targeted {@code List<T>} for conversion
+   */
+  public JsonConverter(@NonNull TypeReference<T> reference) {
+    this.reference = reference;
+  }
 
-    @Override public Subscriber<? super WLResponse> call(final Subscriber<? super T> subscriber) {
-        return new Subscriber<WLResponse>() {
-            @Override public void onCompleted() {
-                if (!subscriber.isUnsubscribed()) {
-                    subscriber.onCompleted();
-                }
-            }
-
-            @Override public void onError(Throwable e) {
-                if (!subscriber.isUnsubscribed()) {
-                    subscriber.onError(e);
-                }
-            }
-
-            @Override public void onNext(WLResponse wlResponse) {
-                if (!subscriber.isUnsubscribed()) {
-                    String json = wlResponse.getResponseJSON().toString();
-                    T converted = convert(json);
-
-                    if (converted == null) {
-                        Throwable e = new Throwable("Could not convert JSON payload: " + json);
-                        subscriber.onError(e);
-                    } else {
-                        subscriber.onNext(converted);
-                    }
-                }
-            }
-        };
-    }
-
-    @Nullable private T convert(String json) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            if (clazz != null) {
-                return mapper.readValue(json, clazz);
-            } else {
-                return mapper.readValue(json, reference);
-            }
-        } catch (IOException e) {
-            e.printStackTrace(); // this should never happen
-            return null;
+  @Override public Subscriber<? super WLResponse> call(final Subscriber<? super T> subscriber) {
+    return new Subscriber<WLResponse>() {
+      @Override public void onCompleted() {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onCompleted();
         }
+      }
+
+      @Override public void onError(Throwable e) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onError(e);
+        }
+      }
+
+      @Override public void onNext(WLResponse wlResponse) {
+        if (!subscriber.isUnsubscribed()) {
+          String json = wlResponse.getResponseJSON().toString();
+          T converted = convert(json);
+
+          if (converted == null) {
+            Throwable e = new Throwable("Could not convert JSON payload: " + json);
+            subscriber.onError(e);
+          } else {
+            subscriber.onNext(converted);
+          }
+        }
+      }
+    };
+  }
+
+  @Nullable private T convert(String json) {
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      if (clazz != null) {
+        return mapper.readValue(json, clazz);
+      } else {
+        return mapper.readValue(json, reference);
+      }
+    } catch (IOException e) {
+      e.printStackTrace(); // this should never happen
+      return null;
     }
+  }
 }

--- a/cafejava/src/main/java/com/ibm/mil/cafejava/ProcedureInvoker.java
+++ b/cafejava/src/main/java/com/ibm/mil/cafejava/ProcedureInvoker.java
@@ -20,16 +20,16 @@ import com.worklight.wlclient.api.WLResponseListener;
  * @author Tanner Preiss (github @t-preiss)
  */
 public interface ProcedureInvoker {
-    /**
-     * Called internally by {@link CafeJava#invokeProcedure(ProcedureInvoker)} in order to invoke
-     * a procedure. The implementation should trigger a procedure invocation, using the {@code
-     * WLResponseListener} argument that is provided.
-     *
-     * @param wlResponseListener Passed in by {@link CafeJava#invokeProcedure(ProcedureInvoker)}
-     *                           and will internally notify subscribers when a response is
-     *                           emitted by the enclosing {@code Observable}. It is important that
-     *                           this {@code WLResponseListener} is used with the procedure
-     *                           invocation.
-     */
-    void invoke(WLResponseListener wlResponseListener);
+  /**
+   * Called internally by {@link CafeJava#invokeProcedure(ProcedureInvoker)} in order to invoke
+   * a procedure. The implementation should trigger a procedure invocation, using the {@code
+   * WLResponseListener} argument that is provided.
+   *
+   * @param wlResponseListener Passed in by {@link CafeJava#invokeProcedure(ProcedureInvoker)}
+   *                           and will internally notify subscribers when a response is
+   *                           emitted by the enclosing {@code Observable}. It is important that
+   *                           this {@code WLResponseListener} is used with the procedure
+   *                           invocation.
+   */
+  void invoke(WLResponseListener wlResponseListener);
 }

--- a/cafejava/src/test/java/com/ibm/mil/cafejava/JsonConverterTest.java
+++ b/cafejava/src/test/java/com/ibm/mil/cafejava/JsonConverterTest.java
@@ -1,14 +1,11 @@
 package com.ibm.mil.cafejava;
 
 import com.worklight.wlclient.api.WLResponse;
-
+import java.util.Arrays;
+import java.util.List;
 import org.codehaus.jackson.type.TypeReference;
 import org.json.JSONObject;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-
 import rx.Observable;
 import rx.functions.Func1;
 import rx.observers.TestSubscriber;
@@ -18,89 +15,87 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class JsonConverterTest {
-    private Observable<WLResponse> observable;
-    private TestSubscriber<Person> subscriber;
+  private Observable<WLResponse> observable;
+  private TestSubscriber<Person> subscriber;
 
-    @Test public void testSimpleObject() {
-        Person person = new Person("John", 25, true);
+  @Test public void testSimpleObject() {
+    Person person = new Person("John", 25, true);
 
-        createMocks(person);
+    createMocks(person);
 
-        observable.lift(new JsonConverter<>(Person.class)).subscribe(subscriber);
+    observable.lift(new JsonConverter<>(Person.class)).subscribe(subscriber);
 
-        subscriber.assertNoErrors();
-        subscriber.assertTerminalEvent();
+    subscriber.assertNoErrors();
+    subscriber.assertTerminalEvent();
 
-        List<Person> persons = subscriber.getOnNextEvents();
-        assertEquals(1, persons.size());
-        assertEquals(person, persons.get(0));
-    }
+    List<Person> persons = subscriber.getOnNextEvents();
+    assertEquals(1, persons.size());
+    assertEquals(person, persons.get(0));
+  }
 
-    @Test public void testSimpleArray() {
-        Person firstPerson = new Person("John", 25, true);
-        Person secondPerson = new Person("Megan", 21, false);
-        List<Person> persons = Arrays.asList(firstPerson, secondPerson);
+  @Test public void testSimpleArray() {
+    Person firstPerson = new Person("John", 25, true);
+    Person secondPerson = new Person("Megan", 21, false);
+    List<Person> persons = Arrays.asList(firstPerson, secondPerson);
 
-        createMocks(persons);
+    createMocks(persons);
 
-        observable.lift(new JsonConverter<>(new TypeReference<List<Person>>() {}))
-                .flatMap(new Func1<List<Person>, Observable<Person>>() {
-                    @Override
-                    public Observable<Person> call(List<Person> persons) {
-                        return Observable.from(persons);
-                    }
-                }).subscribe(subscriber);
+    observable.lift(new JsonConverter<>(new TypeReference<List<Person>>() {
+    })).flatMap(new Func1<List<Person>, Observable<Person>>() {
+      @Override public Observable<Person> call(List<Person> persons) {
+        return Observable.from(persons);
+      }
+    }).subscribe(subscriber);
 
-        subscriber.assertValues(firstPerson, secondPerson);
-    }
+    subscriber.assertValues(firstPerson, secondPerson);
+  }
 
-    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-    @Test public void testBadObject() {
-        createMocks("Not a Person");
+  @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+  @Test public void testBadObject() {
+    createMocks("Not a Person");
 
-        observable.lift(new JsonConverter<>(Person.class)).subscribe(subscriber);
+    observable.lift(new JsonConverter<>(Person.class)).subscribe(subscriber);
 
-        subscriber.assertNoValues();
-        subscriber.assertTerminalEvent();
+    subscriber.assertNoValues();
+    subscriber.assertTerminalEvent();
 
-        List<Throwable> errors = subscriber.getOnErrorEvents();
-        assertEquals(1, errors.size());
+    List<Throwable> errors = subscriber.getOnErrorEvents();
+    assertEquals(1, errors.size());
 
-        Throwable t = errors.get(0);
-        assertEquals("Could not convert JSON payload: Not a Person", t.getMessage());
-    }
+    Throwable t = errors.get(0);
+    assertEquals("Could not convert JSON payload: Not a Person", t.getMessage());
+  }
 
-    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-    @Test public void testBadArray() {
-        Person person = new Person("John", 25, true);
-        createMocks(person);
+  @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+  @Test public void testBadArray() {
+    Person person = new Person("John", 25, true);
+    createMocks(person);
 
-        observable.lift(new JsonConverter<>(new TypeReference<List<Person>>() {}))
-                .flatMap(new Func1<List<Person>, Observable<Person>>() {
-                    @Override
-                    public Observable<Person> call(List<Person> persons) {
-                        return Observable.from(persons);
-                    }
-                }).subscribe(subscriber);
+    observable.lift(new JsonConverter<>(new TypeReference<List<Person>>() {
+    })).flatMap(new Func1<List<Person>, Observable<Person>>() {
+      @Override public Observable<Person> call(List<Person> persons) {
+        return Observable.from(persons);
+      }
+    }).subscribe(subscriber);
 
-        subscriber.assertNoValues();
-        subscriber.assertTerminalEvent();
+    subscriber.assertNoValues();
+    subscriber.assertTerminalEvent();
 
-        List<Throwable> errors = subscriber.getOnErrorEvents();
-        assertEquals(1, errors.size());
+    List<Throwable> errors = subscriber.getOnErrorEvents();
+    assertEquals(1, errors.size());
 
-        Throwable t = errors.get(0);
-        assertEquals("Could not convert JSON payload: " + person.toString(), t.getMessage());
-    }
+    Throwable t = errors.get(0);
+    assertEquals("Could not convert JSON payload: " + person.toString(), t.getMessage());
+  }
 
-    private void createMocks(Object object) {
-        JSONObject jsonObject = mock(JSONObject.class);
-        when(jsonObject.toString()).thenReturn(object.toString());
+  private void createMocks(Object object) {
+    JSONObject jsonObject = mock(JSONObject.class);
+    when(jsonObject.toString()).thenReturn(object.toString());
 
-        WLResponse wlResponse = mock(WLResponse.class);
-        when(wlResponse.getResponseJSON()).thenReturn(jsonObject);
+    WLResponse wlResponse = mock(WLResponse.class);
+    when(wlResponse.getResponseJSON()).thenReturn(jsonObject);
 
-        observable = Observable.just(wlResponse);
-        subscriber = new TestSubscriber<>();
-    }
+    observable = Observable.just(wlResponse);
+    subscriber = new TestSubscriber<>();
+  }
 }

--- a/cafejava/src/test/java/com/ibm/mil/cafejava/Person.java
+++ b/cafejava/src/test/java/com/ibm/mil/cafejava/Person.java
@@ -1,75 +1,74 @@
 package com.ibm.mil.cafejava;
 
+import java.io.IOException;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.IOException;
-
 public class Person {
-    private String name;
-    private int age;
-    private boolean dev;
+  private String name;
+  private int age;
+  private boolean dev;
 
-    public Person() {
-        // required empty constructor for Jackson ObjectMapper
+  public Person() {
+    // required empty constructor for Jackson ObjectMapper
+  }
+
+  public Person(String name, int age, boolean dev) {
+    this.name = name;
+    this.age = age;
+    this.dev = dev;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public boolean isDev() {
+    return dev;
+  }
+
+  public void setDev(boolean dev) {
+    this.dev = dev;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Person)) return false;
+
+    Person that = (Person) o;
+
+    if (name != null ? !name.equals(that.name) : that.name != null) return false;
+    if (age != that.age) return false;
+    if (dev != that.dev) return false;
+
+    return true;
+  }
+
+  @Override public int hashCode() {
+    int result = 1;
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + age;
+    result = 31 * result + (dev ? 1 : 0);
+    return result;
+  }
+
+  @Override public String toString() {
+    try {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (IOException e) {
+      e.printStackTrace();
+      return "";
     }
-
-    public Person(String name, int age, boolean dev) {
-        this.name = name;
-        this.age = age;
-        this.dev = dev;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public int getAge() {
-        return age;
-    }
-
-    public void setAge(int age) {
-        this.age = age;
-    }
-
-    public boolean isDev() {
-        return dev;
-    }
-
-    public void setDev(boolean dev) {
-        this.dev = dev;
-    }
-
-    @Override public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Person)) return false;
-
-        Person that = (Person) o;
-
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
-        if (age != that.age) return false;
-        if (dev != that.dev) return false;
-
-        return true;
-    }
-
-    @Override public int hashCode() {
-        int result = 1;
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + age;
-        result = 31 * result + (dev ? 1 : 0);
-        return result;
-    }
-
-    @Override public String toString() {
-        try {
-            return new ObjectMapper().writeValueAsString(this);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
+  }
 }


### PR DESCRIPTION
Codebase has been reformatted to use [Square's Android code style](https://github.com/square/java-code-styles/blob/master/configs/codestyles/SquareAndroid.xml). A `checkstyle.xml` still needs to be checked in for Travis CI builds.

This PR is in reference to issue #17.